### PR TITLE
Simplify app to single histogram view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.spyproject/*
+*/__pycache__/*


### PR DESCRIPTION
## Summary
- remove the sidebar and session loop to focus the UI on a single histogram workflow
- keep all histogram controls, filters, analytics, and exports within the main page layout
- adjust download naming and session state handling for the single-histogram experience

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68e37141c7508329b96e9c39d36a3160